### PR TITLE
Use SW_RESTORE only if needed

### DIFF
--- a/node_asfw.cc
+++ b/node_asfw.cc
@@ -19,7 +19,20 @@ NAN_METHOD(_SetForegroundWindow) {
     }
 
     HWND hwnd = (HWND)(maybeArg.FromJust());
-    ShowWindow(hwnd, SW_RESTORE);
+    WINDOWPLACEMENT wp;
+    wp.length = sizeof(WINDOWPLACEMENT);
+
+    if (GetWindowPlacement(hwnd, &wp)) {
+		if (wp.showCmd == SW_MINIMIZE || wp.showCmd == SW_SHOWMINIMIZED || wp.showCmd == SW_SHOWMINNOACTIVE) {
+			ShowWindow(hwnd, SW_RESTORE);
+		}
+		else {
+    		ShowWindow(hwnd, SW_SHOW);
+    	}
+	}
+	else {
+		ShowWindow(hwnd, SW_SHOW);
+	}
 
     BOOL ret = SetForegroundWindow(hwnd);
     if (ret == 0) {

--- a/node_asfw.cc
+++ b/node_asfw.cc
@@ -15,7 +15,7 @@ NAN_METHOD(_SetForegroundWindow) {
     }
     auto maybeArg = Nan::To<int64_t>(info[0]);
     if (maybeArg.IsNothing()) {
-        Nan::ThrowError("SetForegroundWindow needs a number argumeng");
+        Nan::ThrowError("SetForegroundWindow needs a number argument");
     }
 
     HWND hwnd = (HWND)(maybeArg.FromJust());
@@ -23,16 +23,16 @@ NAN_METHOD(_SetForegroundWindow) {
     wp.length = sizeof(WINDOWPLACEMENT);
 
     if (GetWindowPlacement(hwnd, &wp)) {
-		if (wp.showCmd == SW_MINIMIZE || wp.showCmd == SW_SHOWMINIMIZED || wp.showCmd == SW_SHOWMINNOACTIVE) {
-			ShowWindow(hwnd, SW_RESTORE);
-		}
-		else {
-    		ShowWindow(hwnd, SW_SHOW);
+        if (wp.showCmd == SW_MINIMIZE || wp.showCmd == SW_SHOWMINIMIZED || wp.showCmd == SW_SHOWMINNOACTIVE) {
+            ShowWindow(hwnd, SW_RESTORE);
+        }
+        else {
+            ShowWindow(hwnd, SW_SHOW);
     	}
-	}
-	else {
-		ShowWindow(hwnd, SW_SHOW);
-	}
+    }
+    else {
+        ShowWindow(hwnd, SW_SHOW);
+    }
 
     BOOL ret = SetForegroundWindow(hwnd);
     if (ret == 0) {


### PR DESCRIPTION
Adds a check to use the SW_RESTORE flag only when required (i.e. when the window is minimized).
SW_SHOW is used otherwise.

See https://docs.microsoft.com/fr-be/windows/win32/api/winuser/ns-winuser-windowplacement for more informations.